### PR TITLE
Reduce path code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,22 @@ function checkArgs(name, ...args) {
   args.forEach((arg, i) => fnArgs[i](name, arg));
 }
 
+function mutatePath(oldObj, path, fn) {
+  const parts = path.split(PATH_DELIMITER);
+  const lastPart = parts.pop();
+  const newObj = {...oldObj};
+
+  let obj = newObj;
+  for (const part of parts) {
+    const v = obj[part];
+    const newV = {...v};
+    obj[part] = newV;
+    obj = newV;
+  }
+  fn(obj, lastPart);
+  return newObj;
+}
+
 export function deepFreeze(obj, freezing = []) {
   checkArgs('deepFreeze', obj);
   if (Object.isFrozen(obj) || freezing.includes(obj)) return;
@@ -40,47 +56,18 @@ export function deepFreeze(obj, freezing = []) {
 
 export function deletePath(oldObj, path) {
   checkArgs('deletePath', oldObj, path);
-
-  const parts = path.split(PATH_DELIMITER);
-  const lastPart = parts.pop();
-  const newObj = {...oldObj};
-
-  let obj = newObj;
-  for (const part of parts) {
-    const v = obj[part];
-    const newV = {...v};
-    obj[part] = newV;
-    obj = newV;
-  }
-
-  delete obj[lastPart];
-
-  return newObj;
+  return mutatePath(oldObj, path, (obj, lastPart) => delete obj[lastPart]);
 }
 
 export function filterPath(oldObj, path, filterFn) {
   checkArgs('filterPath', oldObj, path, filterFn);
-
-  const parts = path.split(PATH_DELIMITER);
-  const lastPart = parts.pop();
-  const newObj = {...oldObj};
-
-  let obj = newObj;
-  for (const part of parts) {
-    const v = obj[part];
-    const newV = {...v};
-    obj[part] = newV;
-    obj = newV;
-  }
-
-  const currentValue = obj[lastPart];
-  if (!Array.isArray(currentValue)) {
-    throw new Error(`filterPath can only be used on arrays and ${path} is not`);
-  }
-
-  obj[lastPart] = currentValue.filter(filterFn);
-
-  return newObj;
+  return mutatePath(oldObj, path, (obj, lastPart) => {
+    const currentValue = obj[lastPart];
+    if (!Array.isArray(currentValue)) {
+      throw new Error(`filterPath can only be used on arrays and ${path} is not`);
+    }
+    obj[lastPart] = currentValue.filter(filterFn);
+  });
 }
 
 export function getPath(obj, path) {
@@ -99,91 +86,34 @@ export function getPath(obj, path) {
 
 export function mapPath(oldObj, path, mapFn) {
   checkArgs('mapPath', oldObj, path, mapFn);
-
-  const parts = path.split(PATH_DELIMITER);
-  const lastPart = parts.pop();
-  const newObj = {...oldObj};
-
-  let obj = newObj;
-  for (const part of parts) {
-    const v = obj[part];
-    const newV = {...v};
-    obj[part] = newV;
-    obj = newV;
-  }
-
-  const currentValue = obj[lastPart];
-  if (!Array.isArray(currentValue)) {
-    throw new Error(`mapPath can only be used on arrays and ${path} is not`);
-  }
-
-  obj[lastPart] = currentValue.map(mapFn);
-
-  return newObj;
+  return mutatePath(oldObj, path, (obj, lastPart) => {
+    const currentValue = obj[lastPart];
+    if (!Array.isArray(currentValue)) {
+      throw new Error(`mapPath can only be used on arrays and ${path} is not`);
+    }
+    obj[lastPart] = currentValue.map(mapFn);
+  });
 }
 
 export function pushPath(oldObj, path, ...values) {
   checkArgs('pushPath', oldObj, path);
-
-  const parts = path.split(PATH_DELIMITER);
-  const lastPart = parts.pop();
-  const newObj = {...oldObj};
-
-  let obj = newObj;
-  for (const part of parts) {
-    const v = obj[part];
-    const newV = {...v};
-    obj[part] = newV;
-    obj = newV;
-  }
-
-  const currentValue = obj[lastPart];
-  if (!Array.isArray(currentValue)) {
-    throw new Error(`pushPath can only be used on arrays and ${path} is not`);
-  }
-
-  obj[lastPart] = [...currentValue, ...values];
-
-  return newObj;
+  return mutatePath(oldObj, path, (obj, lastPart) => {
+    const currentValue = obj[lastPart];
+    if (!Array.isArray(currentValue)) {
+      throw new Error(`pushPath can only be used on arrays and ${path} is not`);
+    }
+    obj[lastPart] = [...currentValue, ...values];
+  });
 }
 
 export function setPath(oldObj, path, value) {
   checkArgs('setPath', oldObj, path);
-
-  const parts = path.split(PATH_DELIMITER);
-  const lastPart = parts.pop();
-  const newObj = {...oldObj};
-
-  let obj = newObj;
-  for (const part of parts) {
-    const v = obj[part];
-    const newV = {...v};
-    obj[part] = newV;
-    obj = newV;
-  }
-
-  obj[lastPart] = value;
-
-  return newObj;
+  return mutatePath(oldObj, path, (obj, lastPart) => obj[lastPart] = value);
 }
 
 export function transformPath(oldObj, path, transformFn) {
   checkArgs('transformPath', oldObj, path, transformFn);
-
-  const parts = path.split(PATH_DELIMITER);
-  const lastPart = parts.pop();
-  const newObj = {...oldObj};
-
-  let obj = newObj;
-  for (const part of parts) {
-    const v = obj[part];
-    const newV = {...v};
-    obj[part] = newV;
-    obj = newV;
-  }
-
-  const currentValue = obj[lastPart];
-  obj[lastPart] = transformFn(currentValue);
-
-  return newObj;
+  return mutatePath(oldObj, path, (obj, lastPart) => {
+    obj[lastPart] = transformFn(obj[lastPart]);
+  });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,28 @@
 const PATH_DELIMITER = '.';
+const fnArgs = [
+  (name, arg) => {
+    if (typeof arg !== 'object') {
+      throw new Error(`${name} first argument must be an object`);
+    }
+  },
+  (name, arg) => {
+    if (typeof arg !== 'string') {
+      throw new Error(`${name} second argument must be a path string`);
+    }
+  },
+  (name, arg) => {
+    if (typeof arg !== 'function') {
+      throw new Error(`${name} third argument must be a function`);
+    }
+  },
+];
+
+function checkArgs(name, ...args) {
+  args.forEach((arg, i) => fnArgs[i](name, arg));
+}
 
 export function deepFreeze(obj, freezing = []) {
-  if (typeof obj !== 'object') {
-    throw new Error('deepFreeze first argument must be an object');
-  }
-
+  checkArgs('deepFreeze', obj);
   if (Object.isFrozen(obj) || freezing.includes(obj)) return;
 
   freezing.push(obj);
@@ -21,13 +39,7 @@ export function deepFreeze(obj, freezing = []) {
 }
 
 export function deletePath(oldObj, path) {
-  if (typeof oldObj !== 'object') {
-    throw new Error('deletePath first argument must be an object');
-  }
-
-  if (typeof path !== 'string') {
-    throw new Error('deletePath second argument must be a path string');
-  }
+  checkArgs('deletePath', oldObj, path);
 
   const parts = path.split(PATH_DELIMITER);
   const lastPart = parts.pop();
@@ -47,17 +59,7 @@ export function deletePath(oldObj, path) {
 }
 
 export function filterPath(oldObj, path, filterFn) {
-  if (typeof oldObj !== 'object') {
-    throw new Error('filterPath first argument must be an object');
-  }
-
-  if (typeof path !== 'string') {
-    throw new Error('filterPath second argument must be a path string');
-  }
-
-  if (typeof filterFn !== 'function') {
-    throw new Error('filterPath third argument must be a function');
-  }
+  checkArgs('filterPath', oldObj, path, filterFn);
 
   const parts = path.split(PATH_DELIMITER);
   const lastPart = parts.pop();
@@ -82,13 +84,7 @@ export function filterPath(oldObj, path, filterFn) {
 }
 
 export function getPath(obj, path) {
-  if (typeof obj !== 'object') {
-    throw new Error('getPath first argument must be an object');
-  }
-
-  if (typeof path !== 'string') {
-    throw new Error('getPath second argument must be a path string');
-  }
+  checkArgs('getPath', obj, path);
 
   if (!path) return undefined;
 
@@ -102,17 +98,7 @@ export function getPath(obj, path) {
 }
 
 export function mapPath(oldObj, path, mapFn) {
-  if (typeof oldObj !== 'object') {
-    throw new Error('mapPath first argument must be an object');
-  }
-
-  if (typeof path !== 'string') {
-    throw new Error('mapPath second argument must be a path string');
-  }
-
-  if (typeof mapFn !== 'function') {
-    throw new Error('mapPath third argument must be a function');
-  }
+  checkArgs('mapPath', oldObj, path, mapFn);
 
   const parts = path.split(PATH_DELIMITER);
   const lastPart = parts.pop();
@@ -137,13 +123,7 @@ export function mapPath(oldObj, path, mapFn) {
 }
 
 export function pushPath(oldObj, path, ...values) {
-  if (typeof oldObj !== 'object') {
-    throw new Error('pushPath first argument must be an object');
-  }
-
-  if (typeof path !== 'string') {
-    throw new Error('pushPath second argument must be a path string');
-  }
+  checkArgs('pushPath', oldObj, path);
 
   const parts = path.split(PATH_DELIMITER);
   const lastPart = parts.pop();
@@ -168,13 +148,7 @@ export function pushPath(oldObj, path, ...values) {
 }
 
 export function setPath(oldObj, path, value) {
-  if (typeof oldObj !== 'object') {
-    throw new Error('setPath first argument must be an object');
-  }
-
-  if (typeof path !== 'string') {
-    throw new Error('setPath second argument must be a path string');
-  }
+  checkArgs('setPath', oldObj, path);
 
   const parts = path.split(PATH_DELIMITER);
   const lastPart = parts.pop();
@@ -194,17 +168,7 @@ export function setPath(oldObj, path, value) {
 }
 
 export function transformPath(oldObj, path, transformFn) {
-  if (typeof oldObj !== 'object') {
-    throw new Error('transformPath first argument must be an object');
-  }
-
-  if (typeof path !== 'string') {
-    throw new Error('transformPath second argument must be a path string');
-  }
-
-  if (typeof transformFn !== 'function') {
-    throw new Error('transformPath third argument must be a function');
-  }
+  checkArgs('transformPath', oldObj, path, transformFn);
 
   const parts = path.split(PATH_DELIMITER);
   const lastPart = parts.pop();


### PR DESCRIPTION
- Reduce down argument checking code by leveraging the consistent argument order for all exported functions
- Reduce down path functions by leveraging `mutatePath` which is similar to `transformPath`, but passes both `obj`, and `lastPath` rather than `obj[lastPath]`
  + Pass a function that takes `obj` and `lastPath` that does the prescribed mutation
  + A further enhancement would be to implement path functions (`filterPath`, `mapPath`, `pushPath`, `setPath`) in terms of `transformPath` to eliminate the `obj[lastPath] = ` portion of the mutate functions